### PR TITLE
Ahmad/FEQ-842/Fibfan drawing blinks on changing zoom

### DIFF
--- a/lib/src/deriv_chart/chart/data_visualization/drawing_tools/fibfan/fibfan_drawing.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/drawing_tools/fibfan/fibfan_drawing.dart
@@ -130,7 +130,9 @@ class FibfanDrawing extends Drawing with LineVectorDrawingMixin {
         ));
   }
 
-  // TODO(NA): Return true if FibfanDrawing's on chart view port.
+// This condition will always return true since Fibfan drawing,
+// will always be out of chart's viewport considering it
+// expand infinitely.
   @override
   bool needsRepaint(
     int leftEpoch,
@@ -184,15 +186,7 @@ class FibfanDrawing extends Drawing with LineVectorDrawingMixin {
     final double endQuoteToY = _endPoint!.y;
 
     if (drawingPart == DrawingParts.marker) {
-      if (endEdgePoint.epoch != 0 && endQuoteToY != 0) {
-        /// Draw second point
-        canvas.drawCircle(
-            Offset(endXCoord, endQuoteToY),
-            markerRadius,
-            drawingData.shouldHighlight
-                ? paint.glowyCirclePaintStyle(lineStyle.color)
-                : paint.transparentCirclePaintStyle());
-      } else if (startEdgePoint.epoch != 0 && startQuoteToY != 0) {
+      if (edgePoints.length == 1) {
         /// Draw first point
         canvas.drawCircle(
             Offset(startXCoord, startQuoteToY),
@@ -248,6 +242,8 @@ class FibfanDrawing extends Drawing with LineVectorDrawingMixin {
       _drawTriangle(canvas, paint, config, _finalInnerVector);
 
       /// Draw markers again to hide their overlap with shadows
+      /// The second cicle is getting created here as the lines and 
+      /// second marker are getting created at same time
       canvas
         ..drawCircle(
             Offset(startXCoord, startQuoteToY),


### PR DESCRIPTION
<!-- Please refer to this [guide](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) for any confusion while creating the PR -->

The PR contains the fix for the random blinking of fibfan drawing tool on web screen when the screen is zoomed in or out . It was noticed that the canvas circle was getting created multiple time due to an invalid conditional operator.

## Pre-launch Checklist (For PR creator)

As a creator of this PR:

- [x] ✍️ I have included clickup id and package/app_name in the PR title. <!-- Find the guide [here](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) -->
- [x] 👁️ I have gone through the code and removed any temporary changes (commented lines, prints, debug statements etc.).
- [x] ⚒️ I have fixed any errors/warnings shown by the analyzer/linter.
- [x] 📝 I have added documentation, comments and logging wherever required.
- [ ] 🧪 I have added necessary tests for these changes.
- [ ] 🔎 I have ensured all existing tests are passing.

