### PR TITLE
[DTRA]/Ahmad/FEQ-1943/Restricting Adx indicator for one tick

### DIFF
--- a/lib/src/deriv_chart/chart/data_visualization/chart_series/indicators_series/adx_series.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/chart_series/indicators_series/adx_series.dart
@@ -204,8 +204,10 @@ class ADXSeries extends Series {
           canvas, size, epochToX, quoteToY, animationInfo, chartConfig, theme);
       negativeDISeries.paint(
           canvas, size, epochToX, quoteToY, animationInfo, chartConfig, theme);
-      adxSeries.paint(
-          canvas, size, epochToX, quoteToY, animationInfo, chartConfig, theme);
+      if (chartConfig.granularity != 1000) {
+        adxSeries.paint(canvas, size, epochToX, quoteToY, animationInfo,
+            chartConfig, theme);
+      }
     }
     if (config.showHistogram) {
       adxHistogramSeries.paint(


### PR DESCRIPTION
<!-- Please refer to this [guide](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) for any confusion while creating the PR -->

**Clickup link:** https://app.clickup.com/t/86bxwva1z
**Fixes issue:** # It doesn't allow adx series indicator to work with 1 tick granularity as it breaks the functionality

This PR contains the following changes:

<!-- Provide a description or list of changes -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


## Pre-launch Checklist (For PR creator)

As a creator of this PR:

<!-- Put an `x` in all the boxes that apply ([x]) -->

- [x] ✍️ I have included clickup id and package/app_name in the PR title. <!-- Find the guide [here](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) -->
- [] 👁️ I have gone through the code and removed any temporary changes (commented lines, prints, debug statements etc.).
- [x] ⚒️ I have fixed any errors/warnings shown by the analyzer/linter.
- [ ] 📝 I have added documentation, comments and logging wherever required.
- [ ] 🧪 I have added necessary tests for these changes.
- [ ] 🔎 I have ensured all existing tests are passing.

## Reviewers

<!-- Tag the reviewers of this PR -->

## Pre-launch Checklist (For Reviewers)

As a reviewer I ensure that:

- [ ] ✴️ This PR follows the standard PR template.
- [ ] 🪩 The information in this PR properly reflects the code changes.
- [ ] 🧪 All the necessary tests for this PR's are passing.

## Pre-launch Checklist (For QA)

- [ ] 👌 It passes the acceptance criteria.

## Pre-launch Checklist (For Maintainer)

- [ ] [MAINTAINER_NAME] I make sure this PR fulfills its purpose.
