### PR TITLE
fix: [GRWT-5941] Override shouldRepaint in vertical barrier

### DIFF
--- a/lib/src/deriv_chart/chart/data_visualization/annotations/barriers/vertical_barrier/vertical_barrier.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/annotations/barriers/vertical_barrier/vertical_barrier.dart
@@ -49,6 +49,9 @@ class VerticalBarrier extends Barrier {
   @override
   BarrierObject createObject() => VerticalBarrierObject(epoch!, quote: quote);
 
+  // Force repaint to ensure vertical barrier gets cleared when out of range.
+  // Safe since onPaint() in [VerticalBarrierPainter] checks
+  // series.isOnRange before drawing.
   @override
   bool shouldRepaint(covariant Barrier previous) {
     return true;

--- a/lib/src/deriv_chart/chart/data_visualization/annotations/barriers/vertical_barrier/vertical_barrier.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/annotations/barriers/vertical_barrier/vertical_barrier.dart
@@ -50,6 +50,11 @@ class VerticalBarrier extends Barrier {
   BarrierObject createObject() => VerticalBarrierObject(epoch!, quote: quote);
 
   @override
+  bool shouldRepaint(covariant Barrier previous) {
+    return true;
+  }
+
+  @override
   List<double> recalculateMinMax() =>
       isOnRange ? super.recalculateMinMax() : <double>[double.nan, double.nan];
 }


### PR DESCRIPTION
<!-- Please refer to this [guide](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) for any confusion while creating the PR -->

**Clickup link:** https://app.clickup.com/t/20696747/GRWT-5941
**Fixes issue:** #<!-- Issue number here, Remove this line if this PR isn't related to any issue -->

This PR contains the following changes:
- To address the issue where the vertical barrier wasn't being cleared from the chart when out of range, we added the shouldRepaint callback and set it to always return true. This ensures that the paint method in `VerticalBarrierPainter` is triggered on every repaint. This approach is safe because the paint method already checks `series.isOnRange` before executing any drawing logic.

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

### Developers Note (Optional)

<!-- REMOVE THIS SECTION IF IT IS NOT NEEDED.>

<!-- Add the reason of making changes in this approach so that it will be helpful to reviewers while reviewing it. -->

## Pre-launch Checklist (For PR creator)

As a creator of this PR:

<!-- Put an `x` in all the boxes that apply ([x]) -->

- [ ] ✍️ I have included clickup id and package/app_name in the PR title. <!-- Find the guide [here](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) -->
- [ ] 👁️ I have gone through the code and removed any temporary changes (commented lines, prints, debug statements etc.).
- [ ] ⚒️ I have fixed any errors/warnings shown by the analyzer/linter.
- [ ] 📝 I have added documentation, comments and logging wherever required.
- [ ] 🧪 I have added necessary tests for these changes.
- [ ] 🔎 I have ensured all existing tests are passing.

## Reviewers

<!-- Tag the reviewers of this PR -->

## Pre-launch Checklist (For Reviewers)

As a reviewer I ensure that:

- [ ] ✴️ This PR follows the standard PR template.
- [ ] 🪩 The information in this PR properly reflects the code changes.
- [ ] 🧪 All the necessary tests for this PR's are passing.

## Pre-launch Checklist (For QA)

- [ ] 👌 It passes the acceptance criteria.

## Pre-launch Checklist (For Maintainer)

- [ ] [MAINTAINER_NAME] I make sure this PR fulfills its purpose.

## Summary by Sourcery

Bug Fixes:
- Ensure the vertical barrier is cleared from the chart when out of range by always returning true in shouldRepaint