### PR TITLE
fix: set drag start on pan update

### DIFF
--- a/lib/src/deriv_chart/interactive_layer/interactive_layer_states/interactive_adding_tool_state.dart
+++ b/lib/src/deriv_chart/interactive_layer/interactive_layer_states/interactive_adding_tool_state.dart
@@ -167,7 +167,6 @@ class InteractiveAddingToolState extends InteractiveState
         StateChangeAnimationDirection.forward,
       );
 
-      _isAddingToolBeingDragged = true;
       _drawingPreview!.onDragStart(
         details,
         epochFromX,
@@ -177,24 +176,24 @@ class InteractiveAddingToolState extends InteractiveState
       );
       return true; // Started dragging the tool being added. Jim - Verify this
     } else {
-      _isAddingToolBeingDragged = false;
       return false; // Not dragging the tool being added. Jim - Verify this
     }
   }
 
   @override
   bool onPanUpdate(DragUpdateDetails details) {
-    if (_isAddingToolBeingDragged) {
-      _drawingPreview?.onDragUpdate(
-        details,
-        epochFromX,
-        quoteFromY,
-        epochToX,
-        quoteToY,
-      );
-      return true; // Dragging the adding tool. Jim - Verify this
+    if (!_isAddingToolBeingDragged) {
+      _isAddingToolBeingDragged = true;
     }
-    return false; // Not dragging the adding tool. Jim - Verify this
+
+    _drawingPreview?.onDragUpdate(
+      details,
+      epochFromX,
+      quoteFromY,
+      epochToX,
+      quoteToY,
+    );
+    return true; // Dragging the adding tool.
   }
 
   @override

--- a/lib/src/deriv_chart/interactive_layer/interactive_layer_states/interactive_selected_tool_state.dart
+++ b/lib/src/deriv_chart/interactive_layer/interactive_layer_states/interactive_selected_tool_state.dart
@@ -90,7 +90,6 @@ class InteractiveSelectedToolState extends InteractiveState
   @override
   bool onPanStart(DragStartDetails details) {
     if (selected.hitTest(details.localPosition, epochToX, quoteToY)) {
-      _draggingStartedOnTool = true;
       selected.onDragStart(details, epochFromX, quoteFromY, epochToX, quoteToY);
       return true; // Started dragging on the selected tool
     } else {
@@ -117,17 +116,18 @@ class InteractiveSelectedToolState extends InteractiveState
 
   @override
   bool onPanUpdate(DragUpdateDetails details) {
-    if (_draggingStartedOnTool) {
-      selected.onDragUpdate(
-        details,
-        epochFromX,
-        quoteFromY,
-        epochToX,
-        quoteToY,
-      );
-      return true; // Dragging a tool
+    if (!_draggingStartedOnTool) {
+      _draggingStartedOnTool = true;
     }
-    return false; // Not dragging a tool
+
+    selected.onDragUpdate(
+      details,
+      epochFromX,
+      quoteFromY,
+      epochToX,
+      quoteToY,
+    );
+    return true; // Dragging a tool
   }
 
   @override


### PR DESCRIPTION
<!-- Please refer to this [guide](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) for any confusion while creating the PR -->

**Clickup link:** https://app.clickup.com/t/20696747/GRWT-6784

This PR contains the following changes:

<!-- Provide a description or list of changes -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

### Developers Note (Optional)

<!-- REMOVE THIS SECTION IF IT IS NOT NEEDED.>

<!-- Add the reason of making changes in this approach so that it will be helpful to reviewers while reviewing it. -->

## Pre-launch Checklist (For PR creator)

As a creator of this PR:

<!-- Put an `x` in all the boxes that apply ([x]) -->

- [ ] ✍️ I have included clickup id and package/app_name in the PR title. <!-- Find the guide [here](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) -->
- [ ] 👁️ I have gone through the code and removed any temporary changes (commented lines, prints, debug statements etc.).
- [ ] ⚒️ I have fixed any errors/warnings shown by the analyzer/linter.
- [ ] 📝 I have added documentation, comments and logging wherever required.
- [ ] 🧪 I have added necessary tests for these changes.
- [ ] 🔎 I have ensured all existing tests are passing.

## Reviewers

<!-- Tag the reviewers of this PR -->

## Pre-launch Checklist (For Reviewers)

As a reviewer I ensure that:

- [ ] ✴️ This PR follows the standard PR template.
- [ ] 🪩 The information in this PR properly reflects the code changes.
- [ ] 🧪 All the necessary tests for this PR's are passing.

## Pre-launch Checklist (For QA)

- [ ] 👌 It passes the acceptance criteria.

## Pre-launch Checklist (For Maintainer)

- [ ] [MAINTAINER_NAME] I make sure this PR fulfills its purpose.

## Summary by Sourcery

Move the drag-start flag assignment into onPanUpdate and remove it from onPanStart for both adding and selected tool states to ensure drag updates are always triggered correctly.

Bug Fixes:
- Initialize the drag-start flags on the first pan update rather than on pan start in InteractiveAddingToolState to consistently invoke onDragUpdate.
- Initialize the drag-start flags on the first pan update rather than on pan start in InteractiveSelectedToolState to consistently invoke onDragUpdate.