### PR TITLE
fix: Jim/fix drawing tools restoration on reload

### DIFF
--- a/lib/src/add_ons/add_ons_repository.dart
+++ b/lib/src/add_ons/add_ons_repository.dart
@@ -12,6 +12,9 @@ typedef CreateAddOn<T extends AddOnConfig> = T Function(
 /// Called when the edit icon is clicked on an add-on.
 typedef OnEditAddOn = Function(int index);
 
+/// Called when an add-on is deleted from the repository.
+typedef OnDeleteAddOn<T extends AddOnConfig> = Function(T item);
+
 /// Holds indicators/drawing tools that were added to the Chart during runtime.
 class AddOnsRepository<T extends AddOnConfig> extends ChangeNotifier
     implements Repository<T> {
@@ -20,6 +23,7 @@ class AddOnsRepository<T extends AddOnConfig> extends ChangeNotifier
     required this.createAddOn,
     required this.sharedPrefKey,
     this.onEditCallback,
+    this.onDeleteCallback,
   }) : _addOns = <T>[];
 
   /// Key String acts as a key for the set of indicators that are saved.
@@ -48,6 +52,9 @@ class AddOnsRepository<T extends AddOnConfig> extends ChangeNotifier
 
   /// Called when the edit icon is clicked.
   OnEditAddOn? onEditCallback;
+
+  /// Called when an add-on is deleted.
+  OnDeleteAddOn? onDeleteCallback;
 
   /// Loads user selected indicators or drawing tools from shared preferences.
   void loadFromPrefs(SharedPreferences prefs, String symbol) {
@@ -111,9 +118,11 @@ class AddOnsRepository<T extends AddOnConfig> extends ChangeNotifier
     if (index < 0 || index >= items.length) {
       return;
     }
-    items.removeAt(index);
+    final removedItem = items.removeAt(index);
     _hiddenStatus.removeAt(index);
     _writeToPrefs();
+    // Notify about the deletion
+    onDeleteCallback?.call(removedItem);
     notifyListeners();
   }
 

--- a/lib/src/deriv_chart/deriv_chart.dart
+++ b/lib/src/deriv_chart/deriv_chart.dart
@@ -236,7 +236,12 @@ class _DerivChartState extends State<DerivChart> {
 
     if (widget.drawingToolsRepo == null &&
         widget.activeSymbol != oldWidget.activeSymbol) {
-      loadSavedIndicatorsAndDrawingTools();
+      // Delay loading until after the widget tree is fully built
+      // This ensures InteractiveLayer and drawingContext are initialized
+      // before syncDrawingsWithConfigs() tries to create InteractableDrawing objects
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        loadSavedIndicatorsAndDrawingTools();
+      });
     }
   }
 
@@ -254,7 +259,12 @@ class _DerivChartState extends State<DerivChart> {
       sharedPrefKey: widget.activeSymbol,
     );
     if (widget.drawingToolsRepo == null) {
-      loadSavedIndicatorsAndDrawingTools();
+      // Delay loading until after the widget tree is fully built
+      // This ensures InteractiveLayer and drawingContext are initialized
+      // before syncDrawingsWithConfigs() tries to create InteractableDrawing objects
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        loadSavedIndicatorsAndDrawingTools();
+      });
     }
   }
 

--- a/lib/src/deriv_chart/interactive_layer/interactive_layer.dart
+++ b/lib/src/deriv_chart/interactive_layer/interactive_layer.dart
@@ -148,20 +148,13 @@ class _InteractiveLayerState extends State<InteractiveLayer> {
   }
 
   void syncDrawingsWithConfigs() {
-    // Safety check: Ensure drawing context is available before creating drawings
-    try {
-      final drawingContext = widget.interactiveLayerBehaviour.interactiveLayer.drawingContext;
-      if (drawingContext.fullSize == Size.zero) {
-        // Drawing context not ready yet, schedule retry after next frame
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) {
-            syncDrawingsWithConfigs();
-          }
-        });
-        return;
-      }
-    } catch (e) {
-      // Interactive layer not ready yet, schedule retry after next frame
+    final interactiveLayerBehaviour = widget.interactiveLayerBehaviour;
+    final interactiveLayer = interactiveLayerBehaviour.interactiveLayer;
+    final drawingContext = interactiveLayer.drawingContext;
+
+    // Ensure drawing context is available before creating drawings
+    if (drawingContext.fullSize == Size.zero) {
+      // Drawing context not ready yet, schedule retry after next frame
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
           syncDrawingsWithConfigs();
@@ -177,8 +170,8 @@ class _InteractiveLayerState extends State<InteractiveLayer> {
       if (!_interactableDrawings.containsKey(config.configId)) {
         // Add new drawing if it doesn't exist
         final drawing = config.getInteractableDrawing(
-          widget.interactiveLayerBehaviour.interactiveLayer.drawingContext,
-          widget.interactiveLayerBehaviour.getToolState,
+          drawingContext,
+          interactiveLayerBehaviour.getToolState,
         );
         _interactableDrawings[config.configId!] = drawing;
       }

--- a/lib/src/deriv_chart/interactive_layer/interactive_layer.dart
+++ b/lib/src/deriv_chart/interactive_layer/interactive_layer.dart
@@ -148,6 +148,28 @@ class _InteractiveLayerState extends State<InteractiveLayer> {
   }
 
   void syncDrawingsWithConfigs() {
+    // Safety check: Ensure drawing context is available before creating drawings
+    try {
+      final drawingContext = widget.interactiveLayerBehaviour.interactiveLayer.drawingContext;
+      if (drawingContext.fullSize == Size.zero) {
+        // Drawing context not ready yet, schedule retry after next frame
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            syncDrawingsWithConfigs();
+          }
+        });
+        return;
+      }
+    } catch (e) {
+      // Interactive layer not ready yet, schedule retry after next frame
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          syncDrawingsWithConfigs();
+        }
+      });
+      return;
+    }
+
     final configListIds =
         widget.drawingToolsRepo.items.map((c) => c.configId).toSet();
 


### PR DESCRIPTION
<!-- Please refer to this [guide](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) for any confusion while creating the PR -->

**Clickup link:** <!-- Add your clickup link here, Remove this line if this PR is not for a task -->
**Fixes issue:** #<!-- Issue number here, Remove this line if this PR isn't related to any issue -->

This PR contains the following changes:

- Improved how drawing tools behave when charts are reloaded and add-ons are removed
- Fixed timing issues by waiting for the right moment (after the widget tree is fully built) to restore tools
- Added a callback to notify the system when add-ons are deleted, keeping everything in sync

<!-- Provide a description or list of changes -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

### Developers Note (Optional)

<!-- REMOVE THIS SECTION IF IT IS NOT NEEDED.>

<!-- Add the reason of making changes in this approach so that it will be helpful to reviewers while reviewing it. -->

## Pre-launch Checklist (For PR creator)

As a creator of this PR:

<!-- Put an `x` in all the boxes that apply ([x]) -->

- [ ] ✍️ I have included clickup id and package/app_name in the PR title. <!-- Find the guide [here](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) -->
- [ ] 👁️ I have gone through the code and removed any temporary changes (commented lines, prints, debug statements etc.).
- [ ] ⚒️ I have fixed any errors/warnings shown by the analyzer/linter.
- [ ] 📝 I have added documentation, comments and logging wherever required.
- [ ] 🧪 I have added necessary tests for these changes.
- [ ] 🔎 I have ensured all existing tests are passing.

## Reviewers

<!-- Tag the reviewers of this PR -->

## Pre-launch Checklist (For Reviewers)

As a reviewer I ensure that:

- [ ] ✴️ This PR follows the standard PR template.
- [ ] 🪩 The information in this PR properly reflects the code changes.
- [ ] 🧪 All the necessary tests for this PR's are passing.

## Pre-launch Checklist (For QA)

- [ ] 👌 It passes the acceptance criteria.

## Pre-launch Checklist (For Maintainer)

- [ ] [MAINTAINER_NAME] I make sure this PR fulfills its purpose.

## Summary by Sourcery

Ensure drawing tools and indicators are only restored once the interactive layer’s drawing context is initialized and add support for deletion callbacks in the add-ons repository

Bug Fixes:
- Guard against zero-size drawingContext in syncDrawingsWithConfigs and retry syncing after the next frame
- Defer loadSavedIndicatorsAndDrawingTools until after widget build via post-frame callback to ensure context initialization

Enhancements:
- Add onDeleteCallback to AddOnsRepository to notify when an add-on is removed
- Refactor interactive_layer to cache interactiveLayerBehaviour and drawingContext locally