### PR TITLE
fix: quote bound animation for disjoint price range

### DIFF
--- a/lib/src/deriv_chart/chart/basic_chart.dart
+++ b/lib/src/deriv_chart/chart/basic_chart.dart
@@ -322,14 +322,31 @@ class BasicChartState<T extends BasicChart> extends State<T>
       maxQuote += 2;
     }
 
-    if (!minQuote.isNaN && minQuote != bottomBoundQuoteTarget) {
+    if (minQuote.isNaN || maxQuote.isNaN) {
+      return;
+    }
+
+    // Snap bounds and skip tick animation when switching to a market with a
+    // disjoint price range, to avoid a long vertical-line artifact.
+    final bool rangeDisjoint =
+        maxQuote < bottomBoundQuoteTarget || minQuote > topBoundQuoteTarget;
+    if (rangeDisjoint) {
+      bottomBoundQuoteTarget = minQuote;
+      bottomBoundQuoteAnimationController.value = minQuote;
+      topBoundQuoteTarget = maxQuote;
+      topBoundQuoteAnimationController.value = maxQuote;
+      completeCurrentTickAnimation();
+      return;
+    }
+
+    if (minQuote != bottomBoundQuoteTarget) {
       bottomBoundQuoteTarget = minQuote;
       bottomBoundQuoteAnimationController.animateTo(
         bottomBoundQuoteTarget,
         curve: Curves.easeOut,
       );
     }
-    if (!maxQuote.isNaN && maxQuote != topBoundQuoteTarget) {
+    if (maxQuote != topBoundQuoteTarget) {
       topBoundQuoteTarget = maxQuote;
       topBoundQuoteAnimationController.animateTo(
         topBoundQuoteTarget,


### PR DESCRIPTION
## Problem

When switching markets (e.g. from EURUSD ~1.08 to XAUUSD ~2000), the chart animates the Y-axis quote bounds and the current spot indicator from the old market's price to the new market's price. Because the price ranges can differ, this creates a jarring long vertical line on screen during the transition.

Two things caused the artifact:

1. **Quote bounds animation** — `_updateQuoteBoundTargets` always called `animateTo` on the bound controllers, even when the new price range had no overlap with the current one.
2. **Current tick animation** — the spot indicator (blinking dot + horizontal barrier) interpolates between `previousLastEntry` and the new last tick on every update. On a market switch the two entries are from completely different price levels, so it slides across a huge vertical gap.

## Solution

Added a **disjoint-range check** in `_updateQuoteBoundTargets`. Before deciding whether to animate, the incoming `[minQuote, maxQuote]` range is compared with the current `[bottomBoundQuoteTarget, topBoundQuoteTarget]`. If the ranges have no overlap at all the data is clearly from a different market, so both transitions are skipped:

- Quote bound controllers are **set directly** (`.value = …`) instead of calling `animateTo`, snapping the Y-axis immediately.
- `completeCurrentTickAnimation()` is called, jumping `currentTickPercent` to `1.0` so the spot indicator renders at the new price without interpolating from the old one.

Normal same-market tick updates always stay within or near the current range, so they are unaffected and continue to use the smooth `animateTo` animation.

```
Old range:  [1.080, 1.090]   (EURUSD)
New range:  [2050,  2100 ]   (XAUUSD)

2050 > 1.090  →  rangeDisjoint = true  →  snap, no animation
```

## Summary by Sourcery

Prevent jarring Y-axis and spot animations when switching between markets with disjoint price ranges.

Bug Fixes:
- Snap quote bounds and current tick position instead of animating when the new market’s price range does not overlap the current range, avoiding long vertical-line artifacts on market switch.
- Ignore quote bound updates when min or max quote values are NaN to avoid invalid animations.