### PR TITLE
fix: prevent stale prevLastEntry animation on market switch

### DIFF
--- a/lib/src/deriv_chart/chart/data_visualization/chart_series/data_series.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/chart_series/data_series.dart
@@ -253,11 +253,13 @@ abstract class DataSeries<T extends Tick> extends Series {
           oldSeries.entries != null &&
           entries!.last == oldSeries.entries!.last) {
         prevLastEntry = oldSeries.prevLastEntry as IndexedEntry<T>?;
-      } else if (oldSeries.entries != null) {
+      } else if (oldSeries.entries != null && _isSameSeries(oldSeries)) {
         prevLastEntry = IndexedEntry<T>(
           oldSeries.entries!.last as T,
           oldSeries.entries!.length - 1,
         );
+        updated = true;
+      } else {
         updated = true;
       }
     } else {
@@ -286,6 +288,24 @@ abstract class DataSeries<T extends Tick> extends Series {
   @protected
   bool isOldDataAvailable(covariant DataSeries<Tick>? oldSeries) =>
       oldSeries?.entries?.isNotEmpty ?? false;
+
+  /// Returns true when [oldSeries] and this series share the same data source,
+  /// i.e. this series is an incremental update of [oldSeries] rather than an
+  /// entirely new dataset (e.g. a market/symbol switch).
+  ///
+  /// Compares the first entries by epoch and quote: for an incremental update
+  /// (new tick, new candle) the beginning of the data is unchanged, so the
+  /// first entries are identical. For a market switch both datasets cover the
+  /// same time window, but the prices differ, so the first entries will not
+  /// match and [prevLastEntry] must not carry over.
+  bool _isSameSeries(DataSeries<Tick> oldSeries) {
+    if (input.isEmpty || (oldSeries.entries?.isEmpty ?? true)) {
+      return false;
+    }
+    final T newFirst = input.first;
+    final Tick oldFirst = oldSeries.entries!.first;
+    return newFirst.epoch == oldFirst.epoch && newFirst.quote == oldFirst.quote;
+  }
 
   @override
   // ignore: avoid_renaming_method_parameters


### PR DESCRIPTION
# fix: prevent stale `prevLastEntry` animation on market switch for OHLC charts

## Problem

When switching markets on a candlestick (or any OHLC) chart, a one-frame glitch
appears on the last candle: a long vertical line shoots from the new market's
candle body down to the old market's price level.

**Root cause chain:**

1. Switching markets calls `setState(() { ticks = fetchedTicks; })`, which
   triggers a rebuild and creates a new `CandleSeries` with the new market's data.
2. `DataSeries.didUpdate(oldSeries)` is called on this new instance with the old
   market's series as `oldData`.
3. Because the last candles differ (`entries!.last != oldSeries.entries!.last`),
   the `else if` branch fires unconditionally and sets:
   ```dart
   prevLastEntry = IndexedEntry(oldSeries.entries!.last, ...)
   ```
   — i.e. `prevLastEntry` now holds the **old market's** last candle (e.g. price ~996).
4. In `OhlcPainter.onPaintData`, the animation logic uses `prevLastEntry` to
   compute `yHigh`:
   ```dart
   yHigh: lastCandle.high > prevLastCandle.entry.high
       ? quoteToY(prevLastCandle.entry.high)   // quoteToY(996) — old market price!
       : quoteToY(lastCandle.high),
   ```
   With the new market's Y-axis range (~1209), `quoteToY(996)` maps far off the
   bottom of the canvas. The wick line is drawn from that off-screen coordinate up
   to `yLow`, producing the visible artifact.

The same tick animation that was fixed for area/line charts in
_fix: quote bound animation for disjoint price range_ does not cover this
case: even after `completeCurrentTickAnimation()` snaps `currentTickPercent` to
`1.0`, the `yHigh/yLow` clamping logic in `OhlcPainter` still reads the stale
`prevLastEntry` in that frame.

## Solution

Add a `_isSameSeries` guard in `DataSeries.didUpdate` so that `prevLastEntry` is
only set when the incoming data is a **continuation** of the old series — not a
wholesale replacement.

```dart
} else if (oldSeries.entries != null && _isSameSeries(oldSeries)) {
    prevLastEntry = IndexedEntry<T>(...);
    updated = true;
} else {
    updated = true;   // data changed, but from a different source — no animation
}
```

`_isSameSeries` compares the **first entries** of both series by epoch and quote:

```dart
bool _isSameSeries(DataSeries<Tick> oldSeries) {
    final T newFirst = input.first;
    final Tick oldFirst = oldSeries.entries!.first;
    return newFirst.epoch == oldFirst.epoch && newFirst.quote == oldFirst.quote;
}
```

For an incremental update (new tick, updated candle) the start of the dataset is
unchanged, so the first entries match → animation runs as before.
For a market switch both datasets span the same time window but at completely
different prices → first quotes differ → `prevLastEntry` is never set → no glitch.

Because `prevLastEntry` is a nullable field initialised to `null` on every new
`DataSeries` instance, not setting it is sufficient — no explicit
`resetLastEntryAnimation()` call is needed.

The `else { updated = true; }` branch is preserved so that the method still
correctly returns `true` on a market switch (new data did arrive), which keeps
compound indicator sub-series recalculation and `_playNewTickAnimation` working
correctly.

## Summary by Sourcery

Guard last-entry animations so that OHLC chart series only animate as continuations of the same data source, preventing visual glitches when switching markets.

Bug Fixes:
- Prevent stale prevLastEntry-based wick animations from using the previous market’s last candle after a market or symbol switch.

Enhancements:
- Introduce a series-identity check based on the first entry’s epoch and quote to distinguish incremental updates from wholesale dataset replacements.