### PR TITLE
fix: disable anti aliasing for chart area

### DIFF
--- a/lib/src/deriv_chart/chart/data_visualization/chart_series/line_series/line_painter.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/chart_series/line_series/line_painter.dart
@@ -38,6 +38,7 @@ class LinePainter extends DataPainter<DataSeries<Tick>> {
     if (style.hasArea) {
       final Paint areaPaint = Paint()
         ..style = PaintingStyle.fill
+        ..isAntiAlias = false
         ..shader = ui.Gradient.linear(
           const Offset(0, 0),
           Offset(0, size.height),


### PR DESCRIPTION
# fix: reduce CPU usage on line chart area fill during Y-axis zoom

## Problem

High CPU usage was observed on the line chart when the Y-axis was zoomed in (vertical padding at minimum). The effect was noticeably worse the more zoomed in the chart was, and improved significantly when zoomed out to maximum padding.

### Root cause

The investigation traced the bottleneck to `canvas.drawPath` in `LinePainter.onPaintData`, specifically the area fill drawn beneath the line series.

The area fill path is closed all the way down to the bottom of the canvas (`size.height`). This means the filled polygon covers a pixel area proportional to how much vertical space the line occupies:

- **Zoomed in (min padding):** the line spreads across most of the canvas height → the filled polygon covers nearly the entire canvas → maximum GPU fill work.
- **Zoomed out (max padding):** the line is compressed into a small band near the centre → the filled polygon covers very few pixels → minimal GPU fill work.

`canvas.drawPath` with `PaintingStyle.fill` must rasterise every pixel inside the polygon. The cost scales directly with the number of pixels covered, so CPU usage rose and fell with the zoom level.

Anti-aliasing compounded the cost. Flutter's rasteriser computes sub-pixel edge coverage for every boundary pixel of the filled polygon. For a large filled shape spanning hundreds of pixels vertically this is significant overhead.

The area fill edges are not visible to the user — they sit directly beneath the stroked line drawn on top — so anti-aliased edges on the fill provide no visual benefit.

## Solution

Disabling anti-aliasing on the area fill paint:

```dart
final Paint areaPaint = Paint()
  ..style = PaintingStyle.fill
  ..isAntiAlias = false   // added
  ..shader = ui.Gradient.linear(...);
```

Setting `isAntiAlias = false` tells the rasteriser to skip sub-pixel edge computation entirely and fill pixels with a hard cutoff. Since the stroke line already covers the fill boundary, the visual result is identical to the user while the per-frame GPU cost is substantially reduced regardless of zoom level.
