### PR TITLE
feat: add counter text type for tick contract markers

### DIFF
--- a/lib/src/deriv_chart/chart/data_visualization/markers/chart_marker.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/markers/chart_marker.dart
@@ -148,6 +148,19 @@ enum MarkerType {
   checkpointSpot,
 }
 
+/// Determines how the [ChartMarker.text] is styled.
+enum MarkerTextType {
+  /// Renders the text in a uniform style.
+  plain,
+
+  /// Renders the text as a progress counter (e.g. `"2/10"`).
+  ///
+  /// The text must contain a `/` separator. The part before `/` is rendered
+  /// prominently to indicate the current value, while the `/` and the part
+  /// after it are rendered smaller to indicate the total.
+  counter,
+}
+
 /// A specialized marker class for displaying various types of markers on a financial chart.
 ///
 /// `ChartMarker` extends the base `Marker` class to provide additional functionality
@@ -195,6 +208,7 @@ class ChartMarker extends Marker {
     VoidCallback? onTap,
     this.markerType,
     this.text,
+    this.textType = MarkerTextType.plain,
     this.color,
     this.hasReducedOpacity = false,
     this.displayOffset = Offset.zero,
@@ -220,6 +234,9 @@ class ChartMarker extends Marker {
   ///
   /// If null, no text is displayed for the marker.
   final String? text;
+
+  /// Controls how [text] is styled.
+  final MarkerTextType textType;
 
   /// The color of the marker.
   ///

--- a/lib/src/deriv_chart/chart/data_visualization/markers/marker_icon_painters/tick_marker_icon_painter.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/markers/marker_icon_painters/tick_marker_icon_painter.dart
@@ -314,7 +314,10 @@ class TickMarkerIconPainter extends MarkerGroupIconPainter {
     ChartTheme theme,
     double opacity,
   ) {
+    // Distance (in pixels) from the start time marker to the right edge of the text label.
     const double _textPaddingFromStartLine = 16;
+
+    // Gap (in pixels) between the text label and adjacent dashed line segments.
     const double _textGap = 4;
 
     final Color textColor =
@@ -324,25 +327,14 @@ class TickMarkerIconPainter extends MarkerGroupIconPainter {
         ? makeDelimitedTextPainter(
             text,
             delimiter: '/',
-            primaryStyle: TextStyle(
-              color: textColor,
-              fontSize: 20,
-              fontWeight: FontWeight.w700,
-            ),
-            secondaryStyle: TextStyle(
-              color: textColor,
-              fontSize: 12,
-              fontWeight: FontWeight.w400,
-            ),
+            primaryStyle: theme.markerStyle.markerCounterPrimaryTextStyle
+                .copyWith(color: textColor),
+            secondaryStyle: theme.markerStyle.markerCounterSecondaryTextStyle
+                .copyWith(color: textColor),
           )
         : makeTextPainter(
             text,
-            TextStyle(
-              color: textColor,
-              fontSize: 12,
-              fontWeight: FontWeight.w700,
-              height: 1,
-            ),
+            theme.markerStyle.markerPlainTextStyle.copyWith(color: textColor),
           );
 
     final double textRight = lineEnd.dx - _textPaddingFromStartLine;

--- a/lib/src/deriv_chart/chart/data_visualization/markers/marker_icon_painters/tick_marker_icon_painter.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/markers/marker_icon_painters/tick_marker_icon_painter.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:deriv_chart/src/deriv_chart/chart/data_visualization/chart_data.dart';
 import 'package:deriv_chart/src/deriv_chart/chart/data_visualization/markers/marker_group.dart';
 import 'package:deriv_chart/src/deriv_chart/chart/data_visualization/markers/marker_icon_painters/marker_group_icon_painter.dart';
@@ -196,16 +197,35 @@ class TickMarkerIconPainter extends MarkerGroupIconPainter {
     YAxisConfig.instance.yAxisClipping(canvas, size, () {
       // Horizontal dashed line from contractMarker to start time
       if (_contractMarkerOffset != null && _startCollapsedOffset != null) {
-        paintHorizontalDashedLine(
-          canvas,
-          _contractMarkerOffset.dx,
-          _startCollapsedOffset.dx,
-          _contractMarkerOffset.dy,
-          finalLineColor,
-          1,
-          dashWidth: 2,
-          dashSpace: 2,
-        );
+        final ChartMarker? contractMarker = markerGroup.markers
+            .firstWhereOrNull((m) => m.markerType == MarkerType.contractMarker);
+        final String? contractText = contractMarker?.text;
+
+        if (contractMarker != null &&
+            contractText != null &&
+            contractText.isNotEmpty) {
+          _paintDashedLineWithText(
+            canvas,
+            _contractMarkerOffset,
+            _startCollapsedOffset,
+            finalLineColor,
+            contractText,
+            contractMarker.textType,
+            theme,
+            opacity,
+          );
+        } else {
+          paintHorizontalDashedLine(
+            canvas,
+            _startCollapsedOffset.dx,
+            _contractMarkerOffset.dx,
+            _contractMarkerOffset.dy,
+            finalLineColor,
+            1,
+            dashWidth: 2,
+            dashSpace: 2,
+          );
+        }
       }
 
       final Paint solidLinePaint = Paint()
@@ -277,6 +297,92 @@ class TickMarkerIconPainter extends MarkerGroupIconPainter {
         );
       }
     });
+  }
+
+  /// Draws the dashed connector line with a text label split into it.
+  ///
+  /// The text is positioned near [lineEnd] (the start time collapsed marker)
+  /// with a small padding gap. The dashed line is drawn on both sides of the
+  /// text.
+  void _paintDashedLineWithText(
+    Canvas canvas,
+    Offset lineStart,
+    Offset lineEnd,
+    Color lineColor,
+    String text,
+    MarkerTextType textType,
+    ChartTheme theme,
+    double opacity,
+  ) {
+    const double _textPaddingFromStartLine = 16;
+    const double _textGap = 4;
+
+    final Color textColor =
+        theme.markerStyle.markerTextColor.withOpacity(opacity);
+
+    final TextPainter textPainter = textType == MarkerTextType.counter
+        ? makeDelimitedTextPainter(
+            text,
+            delimiter: '/',
+            primaryStyle: TextStyle(
+              color: textColor,
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+            ),
+            secondaryStyle: TextStyle(
+              color: textColor,
+              fontSize: 12,
+              fontWeight: FontWeight.w400,
+            ),
+          )
+        : makeTextPainter(
+            text,
+            TextStyle(
+              color: textColor,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              height: 1,
+            ),
+          );
+
+    final double textRight = lineEnd.dx - _textPaddingFromStartLine;
+    final double textLeft = textRight - textPainter.width;
+
+    if (lineStart.dx < textLeft - _textGap) {
+      // Left portion of dashed line.
+      paintHorizontalDashedLine(
+        canvas,
+        textLeft - _textGap,
+        lineStart.dx,
+        lineStart.dy,
+        lineColor,
+        1,
+        dashWidth: 2,
+        dashSpace: 2,
+      );
+    }
+
+    // Right portion of dashed line (text to startTimeCollapsed).
+    if (lineStart.dx < lineEnd.dx) {
+      paintHorizontalDashedLine(
+        canvas,
+        textRight + _textGap,
+        lineEnd.dx,
+        lineStart.dy,
+        lineColor,
+        1,
+        dashWidth: 2,
+        dashSpace: 2,
+      );
+    }
+
+    // Draw text centered vertically on the line.
+    paintWithTextPainter(
+      canvas,
+      painter: textPainter,
+      anchor: Offset(textLeft, lineStart.dy),
+      anchorAlignment: Alignment.centerLeft,
+    );
   }
 
   /// Renders an individual marker based on its type.

--- a/lib/src/deriv_chart/chart/helpers/paint_functions/paint_text.dart
+++ b/lib/src/deriv_chart/chart/helpers/paint_functions/paint_text.dart
@@ -74,6 +74,33 @@ TextPainter makeFittedTextPainter(
   return makeTextPainter(text, fittedStyle);
 }
 
+/// Constructs a [TextPainter] by splitting [text] on the first occurrence of
+/// [delimiter] and applying [primaryStyle] to the part before it and
+/// [secondaryStyle] to the delimiter and the part after it.
+///
+/// Falls back to [makeTextPainter] with [primaryStyle] if [delimiter] is not
+/// found or appears at the start of [text].
+TextPainter makeDelimitedTextPainter(
+  String text, {
+  required String delimiter,
+  required TextStyle primaryStyle,
+  required TextStyle secondaryStyle,
+}) {
+  final int index = text.indexOf(delimiter);
+  if (index > 0) {
+    return TextPainter(
+      text: TextSpan(
+        children: [
+          TextSpan(text: text.substring(0, index), style: primaryStyle),
+          TextSpan(text: text.substring(index), style: secondaryStyle),
+        ],
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+  }
+  return makeTextPainter(text, primaryStyle);
+}
+
 /// Paints on the canvas with the given text painter.
 void paintWithTextPainter(
   Canvas canvas, {

--- a/lib/src/theme/chart_default_dark_theme.dart
+++ b/lib/src/theme/chart_default_dark_theme.dart
@@ -256,5 +256,6 @@ class ChartDefaultDarkTheme extends ChartDefaultTheme {
         lineDefaultColor: DarkThemeColors.markerPaletteBorderColor,
         upColorProminent: DarkThemeColors.upColorProminent,
         downColorProminent: DarkThemeColors.downColorProminent,
+        markerTextColor: DarkThemeColors.markerTextColor,
       );
 }

--- a/lib/src/theme/chart_default_light_theme.dart
+++ b/lib/src/theme/chart_default_light_theme.dart
@@ -256,5 +256,6 @@ class ChartDefaultLightTheme extends ChartDefaultTheme {
         lineDefaultColor: LightThemeColors.markerPaletteBorderColor,
         upColorProminent: LightThemeColors.upColorProminent,
         downColorProminent: LightThemeColors.downColorProminent,
+        markerTextColor: LightThemeColors.markerTextColor,
       );
 }

--- a/lib/src/theme/colors.dart
+++ b/lib/src/theme/colors.dart
@@ -175,6 +175,9 @@ class LightThemeColors {
       LightThemeDesignTokens.semanticColorEmeraldSolidBorderInverseHigh;
   static const Color downColorProminent =
       LightThemeDesignTokens.semanticColorCherrySolidBorderInverseHigh;
+
+  static const Color markerTextColor =
+      ComponentDesignTokens.componentTextIconNormalProminentLight;
 }
 
 /// Default colors for dark theme.
@@ -310,6 +313,9 @@ class DarkThemeColors {
       DarkThemeDesignTokens.semanticColorEmeraldSolidBorderInverseHigh;
   static const Color downColorProminent =
       DarkThemeDesignTokens.semanticColorCherrySolidBorderInverseHigh;
+
+  static const Color markerTextColor =
+      ComponentDesignTokens.componentTextIconNormalProminentDark;
 }
 
 /// Candle Bullish colors for light, dark

--- a/lib/src/theme/painting_styles/marker_style.dart
+++ b/lib/src/theme/painting_styles/marker_style.dart
@@ -36,6 +36,22 @@ class MarkerStyle extends ChartPaintingStyle {
       fontSize: 12,
       fontWeight: FontWeight.w700,
     ),
+    this.markerPlainTextStyle = const TextStyle(
+      color: Colors.white,
+      fontSize: 12,
+      fontWeight: FontWeight.w700,
+      height: 1,
+    ),
+    this.markerCounterPrimaryTextStyle = const TextStyle(
+      color: Colors.white,
+      fontSize: 20,
+      fontWeight: FontWeight.w700,
+    ),
+    this.markerCounterSecondaryTextStyle = const TextStyle(
+      color: Colors.white,
+      fontSize: 12,
+      fontWeight: FontWeight.w400,
+    ),
     this.startTimeIcon = QuillIcons.stopwatch,
     this.endTimeIcon = QuillIcons.flag_checkered,
   });
@@ -93,4 +109,17 @@ class MarkerStyle extends ChartPaintingStyle {
 
   /// Style of the marker label.
   final TextStyle markerLabelTextStyle;
+
+  /// Text style for plain marker text displayed on the connector line.
+  final TextStyle markerPlainTextStyle;
+
+  /// Text style for the primary (current value) part of a counter marker text.
+  ///
+  /// Applied to the portion before the `/` separator (e.g. `"2"` in `"2/10"`).
+  final TextStyle markerCounterPrimaryTextStyle;
+
+  /// Text style for the secondary (total value) part of a counter marker text.
+  ///
+  /// Applied to the `/` separator and the portion after it (e.g. `"/10"` in `"2/10"`).
+  final TextStyle markerCounterSecondaryTextStyle;
 }

--- a/lib/src/theme/painting_styles/marker_style.dart
+++ b/lib/src/theme/painting_styles/marker_style.dart
@@ -17,6 +17,7 @@ class MarkerStyle extends ChartPaintingStyle {
     this.lineProfitColor = const Color(0xFF008832),
     this.lineLossColor = const Color(0xFFE6190E),
     this.lineDefaultColor = const Color(0xFFCED0D6),
+    this.markerTextColor = const Color(0xFFFFFFFF),
     this.radius = 12.0,
     this.activeMarkerText = const TextStyle(
       color: Colors.black,
@@ -62,6 +63,9 @@ class MarkerStyle extends ChartPaintingStyle {
 
   /// Color of line for its default state.
   final Color lineDefaultColor;
+
+  /// Color of the text displayed for a marker.
+  final Color markerTextColor;
 
   /// Radius of a single marker.
   final double radius;


### PR DESCRIPTION
## Summary

This PR introduces a `MarkerTextType` enum and the supporting rendering logic to display styled text inline on the dashed connector line of a contract marker; specifically to show a live tick counter (e.g. **2**/10) for tick-duration contracts.

## Changes

### `ChartMarker` / `MarkerType`
- Added `MarkerTextType` enum with two variants:
  - `plain` — renders the text in a uniform style (default, backward-compatible)
  - `counter` — splits the text on `/` and renders the left part prominently (larger, bold) and the right part (including `/`) smaller, to convey a "current / total" progress

- Added `textType` field to `ChartMarker` (defaults to `MarkerTextType.plain`)

### `TickMarkerIconPainter`
- When a `contractMarker` has non-empty `text`, the dashed connector line is now split around an inline text label instead of drawing a plain line
- A new private `_paintDashedLineWithText` method handles layout: it positions the text near the start-time marker, then draws the dashed line in two segments on either side

### `paint_text.dart`
- Added `makeDelimitedTextPainter`. a helper that splits a string on a given delimiter and builds a `TextPainter` with a `TextSpan` applying different styles to each part

### Theme
- Added `markerTextColor` to `MarkerStyle` and wired it up in both `ChartDefaultDarkTheme` and `ChartDefaultLightTheme` using the appropriate design tokens

## How it works

```
contractMarker.text     = "2/10"
contractMarker.textType = MarkerTextType.counter
```

The painter splits `"2/10"` at `/`, renders `"2"` at 20 px / bold and `"/10"` at 12 px / regular, then draws the dashed line on both sides of the label along the connector.

For markers without text (or with `textType: plain`) the existing rendering path is unchanged.

## Summary by Sourcery

Add support for styled inline text on contract marker connector lines, enabling counter-style tick labels and theming for marker text.

New Features:
- Introduce MarkerTextType enum and textType property on ChartMarker to control marker text styling, including a new counter style for progress-like labels.
- Add inline text rendering on the tick contract dashed connector line, splitting the line around the label when marker text is present.
- Provide a makeDelimitedTextPainter helper to build differently styled text segments from a delimited string.

Enhancements:
- Extend MarkerStyle and chart themes with a configurable markerTextColor used when rendering marker text.