### PR TITLE
fix: current tick animation snap

### DIFF
--- a/lib/src/deriv_chart/chart/basic_chart.dart
+++ b/lib/src/deriv_chart/chart/basic_chart.dart
@@ -163,10 +163,21 @@ class BasicChartState<T extends BasicChart> extends State<T>
     _updateChartPosition();
   }
 
-  /// Whether the chart data did update or not.
-  void didUpdateChartData(BasicChart oldChart) {
+  /// Updates the main series against [oldChart] and, when its data actually
+  /// advanced, plays the current-tick transition animation.
+  ///
+  /// Returns whether the main series' data advanced (a new/changed last entry,
+  /// or a fresh dataset). [DataSeries.didUpdate] returns `false` for rebuilds
+  /// that don't change the data — e.g. when the host app rebuilds the chart
+  /// from tick-independent state (barriers, price proposals, running-contract
+  /// P&L streams). Subclasses combine this with their own data (e.g.
+  /// annotations) to decide whether to drive the shared animation — see
+  /// [MainChart.didUpdateChartData].
+  bool didUpdateChartData(BasicChart oldChart) {
+    // Whether the main series' data actually advanced.
+    bool dataUpdated = false;
     if (widget.mainSeries.id == oldChart.mainSeries.id) {
-      widget.mainSeries.didUpdate(oldChart.mainSeries);
+      dataUpdated = widget.mainSeries.didUpdate(oldChart.mainSeries);
     }
 
     if (widget.currentTickAnimationDuration.inMilliseconds !=
@@ -185,7 +196,17 @@ class BasicChartState<T extends BasicChart> extends State<T>
       _setupBoundsAnimation();
     }
 
-    _playNewTickAnimation();
+    // Only drive the current-tick animation on a genuine data advance.
+    // Without this guard, a consumer that rebuilds the chart frequently from
+    // tick-independent streams starts spurious animation cycles; because the
+    // controller is shared, a real tick arriving mid-cycle is then skipped by
+    // [playNewTickAnimation]'s `_isTickAnimationPlaying` guard and snaps into
+    // place instead of animating smoothly.
+    if (dataUpdated) {
+      playNewTickAnimation();
+    }
+
+    return dataUpdated;
   }
 
   @override
@@ -220,7 +241,12 @@ class BasicChartState<T extends BasicChart> extends State<T>
     return gridLineQuotes!;
   }
 
-  void _playNewTickAnimation() {
+  /// Starts a fresh current-tick transition animation, unless one is already
+  /// in flight (in which case this is a no-op so the running animation is not
+  /// truncated). Protected so subclasses can drive it after evaluating their
+  /// own data — see [MainChart.didUpdateChartData].
+  @protected
+  void playNewTickAnimation() {
     if (!_isTickAnimationPlaying) {
       _currentTickAnimationController
         ..reset()

--- a/lib/src/deriv_chart/chart/main_chart.dart
+++ b/lib/src/deriv_chart/chart/main_chart.dart
@@ -217,8 +217,6 @@ class _ChartImplementationState extends BasicChartState<MainChart> {
   void didUpdateWidget(MainChart oldChart) {
     super.didUpdateWidget(oldChart);
 
-    didUpdateChartData(oldChart);
-
     if (widget.isLive != oldChart.isLive ||
         widget.showCurrentTickBlinkAnimation !=
             oldChart.showCurrentTickBlinkAnimation) {

--- a/lib/src/deriv_chart/chart/main_chart.dart
+++ b/lib/src/deriv_chart/chart/main_chart.dart
@@ -274,8 +274,11 @@ class _ChartImplementationState extends BasicChartState<MainChart> {
   }
 
   @override
-  void didUpdateChartData(covariant MainChart oldChart) {
-    super.didUpdateChartData(oldChart);
+  bool didUpdateChartData(covariant MainChart oldChart) {
+    // Whether the main series advanced. super() already plays the current-tick
+    // animation in that case.
+    bool dataUpdated = super.didUpdateChartData(oldChart);
+
     for (final ChartData data in widget.chartDataList.where(
       // Exclude mainSeries, since its didUpdate is already called
       (ChartData d) => d.id != widget.mainSeries.id,
@@ -284,8 +287,26 @@ class _ChartImplementationState extends BasicChartState<MainChart> {
         (ChartData d) => d.id == data.id,
       );
 
-      data.didUpdate(oldData);
+      // Annotations (barriers, the accumulator indicator, etc.) animate their
+      // position by lerping previousObject -> new object with the SAME
+      // currentTickPercent as the main series (see _buildAnnotations). Fold
+      // their update flags in so an annotation that moves WITHOUT a new tick
+      // (e.g. the accumulators barrier, which arrives on a separate WS
+      // subscription and is released ~500 ms after the tick) still drives the
+      // shared animation instead of snapping to its new position.
+      if (data.didUpdate(oldData)) {
+        dataUpdated = true;
+      }
     }
+
+    // If only an annotation advanced, super() did not start the animation —
+    // start it here. Harmless when the main series already started it
+    // (playNewTickAnimation is a no-op while an animation is in flight).
+    if (dataUpdated) {
+      playNewTickAnimation();
+    }
+
+    return dataUpdated;
   }
 
   @override


### PR DESCRIPTION
# Fix: chart data snaps instead of animating under frequent rebuilds

## Summary

The transition animation for the last tick — and for barriers/indicators —
intermittently **snaps** to its new position instead of sliding, producing a
jerky chart. This happens for consumers that rebuild the chart frequently from
tick-independent streams (price proposals, contract P&L, barriers).

The fix: only run the animation when the chart data **actually changed**,
instead of on every rebuild.

## Problem

The tick animation and all annotations share one `AnimationController`
(`currentTickAnimation`, 300 ms), started by:

```dart
void playNewTickAnimation() {
  if (!_isTickAnimationPlaying) {   // don't restart while an animation is running
    _currentTickAnimationController..reset()..forward();
  }
}
```

`didUpdateChartData()` called this on **every** rebuild — including rebuilds
that carry no new data. When the chart is rebuilt often by tick-independent
streams, each such rebuild starts a **spurious** empty animation cycle that
holds `_isTickAnimationPlaying = true` for 300 ms.

When a **real** tick then arrives during that window, the
`if (!_isTickAnimationPlaying)` guard skips its `reset()..forward()`. The
controller finishes the spurious cycle instead; if it was near the end,
`currentTickPercent` hits `1` immediately and the new value is painted directly
at its final position → **snap**. Hence the intermittent jerkiness, worse
during active trading.

## Fix

`didUpdate()` already returns `true` only when the data genuinely advanced
(new/changed last tick, or a moved annotation) and `false` for no-op rebuilds —
but that return value was ignored. We now use it to gate the animation.

**`BasicChart`** — gate on the main series, and return whether it advanced:

```dart
bool didUpdateChartData(BasicChart oldChart) {
  bool dataUpdated = false;
  if (widget.mainSeries.id == oldChart.mainSeries.id) {
    dataUpdated = widget.mainSeries.didUpdate(oldChart.mainSeries);
  }
  // ... unchanged duration/bounds handling ...
  if (dataUpdated) playNewTickAnimation();
  return dataUpdated;
}
```

**`MainChart`** — barriers/indicators are annotations that animate off the
*same* controller, and can move **without a new tick** (e.g. the accumulators
barrier arrives on a separate subscription, ~500 ms after the tick). So fold
their `didUpdate()` results into the gate too, otherwise they snap:

```dart
bool didUpdateChartData(covariant MainChart oldChart) {
  bool dataUpdated = super.didUpdateChartData(oldChart); // main series

  for (final data in widget.chartDataList.where((d) => d.id != widget.mainSeries.id)) {
    final oldData = oldChart.chartDataList.firstWhereOrNull((d) => d.id == data.id);
    if (data.didUpdate(oldData)) dataUpdated = true; // an annotation moved
  }

  if (dataUpdated) playNewTickAnimation(); // no-op if super already started it
  return dataUpdated;
}
```

## Summary by Sourcery

Gate the current-tick chart animation on actual data changes to prevent snapping under frequent rebuilds.

Bug Fixes:
- Prevent intermittent snapping of the last tick and annotations by only triggering the shared animation controller when chart data or annotations truly update.

Enhancements:
- Refine BasicChart and MainChart update hooks to return whether data advanced and expose a protected animation trigger for coordinated use by subclasses.