### PR TITLE
fix: crosshair type error

### DIFF
--- a/lib/src/deriv_chart/chart/data_visualization/chart_series/data_series.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/chart_series/data_series.dart
@@ -363,6 +363,22 @@ abstract class DataSeries<T extends Tick> extends Series {
   Widget getCrossHairInfo(T crossHairTick, int pipSize, ChartTheme theme,
       CrosshairVariant crosshairVariant);
 
+  /// Whether [tick] is compatible with this series' data type [T].
+  ///
+  /// Crosshair-related methods such as [getCrosshairHighlightPainter] and
+  /// [getCrossHairInfo] declare their parameter as `T`. Because Dart generics
+  /// are covariant with a runtime check, invoking them through a
+  /// `DataSeries<Tick>` reference with an argument that is not actually a `T`
+  /// throws a fatal `TypeError` (e.g. `'Tick' is not a subtype of 'Candle'`).
+  ///
+  /// This can happen transiently when the crosshair still holds a tick from a
+  /// previous series while the active series has already been swapped for a
+  /// different type (switching chart type / granularity / symbol while the
+  /// crosshair is visible). Callers should check this before forwarding a tick
+  /// to those methods and skip rendering the crosshair for that frame when it
+  /// returns `false` — the next frame supplies a matching tick.
+  bool isTickCompatible(Tick tick) => tick is T;
+
   /// Returns a CrosshairHighlightPainter for highlighting the element at the crosshair position.
   /// Each series type should implement this to return the appropriate highlight painter.
   ///

--- a/lib/src/deriv_chart/interactive_layer/crosshair/crosshair_area.dart
+++ b/lib/src/deriv_chart/interactive_layer/crosshair/crosshair_area.dart
@@ -142,6 +142,18 @@ class CrosshairArea extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
+    // Guard against a tick whose runtime type does not match [mainSeries].
+    // Forwarding it to the series' crosshair methods (getCrosshairHighlightPainter,
+    // getCrossHairInfo) would throw a fatal covariant-generic downcast
+    // TypeError (e.g. 'Tick' is not a subtype of 'Candle'). This mismatch is
+    // transient — it occurs when the crosshair still holds a tick from a
+    // previous series while the active series has already been swapped (chart
+    // type / granularity / symbol change while the crosshair is visible).
+    // Skipping this frame lets the next frame render with a matching tick.
+    if (!mainSeries.isTickCompatible(tick)) {
+      return const SizedBox.shrink();
+    }
+
     final XAxisModel xAxis = context.watch<XAxisModel>();
     final ChartTheme theme = context.read<ChartTheme>();
     return Stack(


### PR DESCRIPTION
# Fix: crosshair crashlytics error when switching chart type while crosshair is visible

## Problem

```
FlutterError - type 'Tick' is not a subtype of type 'Candle' of 'crosshairTick'
  HollowCandleSeries.getCrosshairHighlightPainter (hollow_candle_series.dart:57)
  CrosshairArea._buildCrosshairTickHightlight (crosshair_area.dart:285)
```

**Root cause — a covariant-generic downcast failure.**

Candle series (`CandleSeries`, `HollowCandleSeries`, `OhlcCandleSeries`) extend `DataSeries<Candle>`, so their crosshair methods (`getCrosshairHighlightPainter`, `getCrossHairInfo`) require a `Candle`. `CrosshairArea` calls these through a `DataSeries<Tick>` reference. Because Dart generics are covariant, this compiles — but Dart inserts a **runtime type check on the argument**, which throws at the parameter (before the method body runs) when the argument is a plain `Tick` rather than a `Candle`.

This happens because the crosshair keeps its held data point (`CrosshairState.crosshairTick`) across rebuilds. When the active series is swapped for a **different element type** while the crosshair is still visible — e.g. switching chart type between line/area (`Tick`-based `LineSeries`) and candle/hollow-candle/OHLC (`Candle`-based) — there is a transient frame where `mainSeries` is already a candle series but the crosshair still holds a `Tick` from the previous series. Forwarding that stale `Tick` into the candle series' crosshair methods throws the fatal `TypeError`.

## Fix

Guard the single crosshair choke point so a tick whose runtime type doesn't match the active series is skipped for that frame, instead of being forwarded into a covariant downcast.

- **`data_series.dart`** — add a base predicate that works for every series via the reified type parameter `T`:
  ```dart
  bool isTickCompatible(Tick tick) => tick is T;
  ```
  Line/area series (`T == Tick`) accept any tick; candle series (`T == Candle`) reject plain ticks.

- **`crosshair_area.dart`** — in `buildCrosshairContent`, bail out early when the tick is incompatible with `mainSeries`:
  ```dart
  if (!mainSeries.isTickCompatible(tick)) {
    return const SizedBox.shrink();
  }
  ```
  This one guard protects **both** crash paths (highlight painter and details box), since both are gated here.

The crosshair simply doesn't render for the single transient frame; the next frame derives a fresh, type-matching data point from the swapped series and renders normally. No behavioural change in the steady state.

## Summary by Sourcery

Prevent crosshair rendering from causing type errors when chart series types change while the crosshair is visible.

Bug Fixes:
- Avoid a runtime TypeError in crosshair rendering when a stale tick from a previous series is used after switching to a series with a different data type.

Enhancements:
- Introduce a generic compatibility check on data series ticks so crosshair logic can safely skip incompatible ticks for a frame instead of crashing.