### PR TITLE
fix: zigzag indicator range error

### DIFF
--- a/lib/src/deriv_chart/chart/data_visualization/chart_series/indicators_series/zigzag_series.dart
+++ b/lib/src/deriv_chart/chart/data_visualization/chart_series/indicators_series/zigzag_series.dart
@@ -43,7 +43,17 @@ class ZigZagSeries extends LineSeries {
   VisibleEntries<Tick> getVisibleEntries(int startIndex, int endIndex) {
     int firstIndex = startIndex;
     int lastIndex = endIndex;
-    if (entries == null || startIndex < 0 || endIndex - 1 > entries!.length) {
+    // `startIndex`/`endIndex` are -1 when the visible window falls entirely
+    // outside the data range — e.g. right after a granularity switch, while
+    // the x-axis still holds the previous interval's epochs. The base
+    // implementation treats that as "nothing visible", and so must this one:
+    // the lookups below read `entries![endIndex - 1]`, which would be a
+    // negative index.
+    if (entries == null ||
+        startIndex < 0 ||
+        startIndex >= entries!.length ||
+        endIndex < 1 ||
+        endIndex > entries!.length) {
       return VisibleEntries<Tick>.empty();
     }
     if (entries![startIndex].quote.isNaN) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
 
   collection: ^1.18.0
-  deriv_technical_analysis: ^1.1.1
+  deriv_technical_analysis: ^1.1.3
   equatable: ^2.0.5
   intl: ^0.19.0
   json_annotation: ^4.8.0

--- a/test/deriv_chart/chart/data_visualization/chart_series/indicator_series/zigzag_series_test.dart
+++ b/test/deriv_chart/chart/data_visualization/chart_series/indicator_series/zigzag_series_test.dart
@@ -1,0 +1,54 @@
+import 'package:deriv_chart/deriv_chart.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ZigZagSeries visible entries', () {
+    // Epochs deliberately start well after 0 so a visible window can sit
+    // entirely to the left of the data.
+    late IndicatorInput input;
+
+    setUp(() {
+      input = IndicatorInput(
+        const <Tick>[
+          Tick(epoch: 5000, quote: 1),
+          Tick(epoch: 6000, quote: 3),
+          Tick(epoch: 7000, quote: 2),
+          Tick(epoch: 8000, quote: 4),
+        ],
+        1000,
+      );
+    });
+
+    test('is empty when the visible window is entirely before the data', () {
+      // Reproduces a granularity switch: the x-axis still holds the previous
+      // interval's epochs, so the window has no overlap with the new series
+      // and the upper index search returns its -1 sentinel.
+      final ZigZagSeries series = ZigZagSeries(input)..update(1000, 2000);
+
+      expect(series.visibleEntries.isEmpty, true);
+    });
+
+    test('is empty when the visible window is entirely after the data', () {
+      final ZigZagSeries series = ZigZagSeries(input)..update(20000, 30000);
+
+      expect(series.visibleEntries.isEmpty, true);
+    });
+
+    test('is empty when the visible window is before a single-entry series',
+        () {
+      // The narrowest case, and the one seen in production: with one entry the
+      // out-of-range read is `entries[-2]`.
+      final ZigZagSeries series = ZigZagSeries(
+        IndicatorInput(const <Tick>[Tick(epoch: 5000, quote: 1)], 1000),
+      )..update(1000, 2000);
+
+      expect(series.visibleEntries.isEmpty, true);
+    });
+
+    test('returns entries when the visible window overlaps the data', () {
+      final ZigZagSeries series = ZigZagSeries(input)..update(5000, 8000);
+
+      expect(series.visibleEntries.isEmpty, false);
+    });
+  });
+}


### PR DESCRIPTION
<!-- Please refer to this [guide](https://github.com/deriv-com/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) for any confusion while creating the PR -->

**Clickup link:** <!-- Add your clickup link here, Remove this line if this PR is not for a task -->
**Fixes issue:** #<!-- Issue number here, Remove this line if this PR isn't related to any issue -->

This PR contains the following changes:
- upgrade to deriv_technical_analysis v1.1.3
-  prevent RangeError in ZigZagIndicator when the input contains no swing before the last entry. The first-swing search read one entry past the end of the list.

<!-- Provide a description or list of changes -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

### Developers Note (Optional)

<!-- REMOVE THIS SECTION IF IT IS NOT NEEDED.>

<!-- Add the reason of making changes in this approach so that it will be helpful to reviewers while reviewing it. -->

## Pre-launch Checklist (For PR creator)

As a creator of this PR:

<!-- Put an `x` in all the boxes that apply ([x]) -->

- [ ] ✍️ I have included clickup id and package/app_name in the PR title. <!-- Find the guide [here](https://github.com/deriv-com/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) -->
- [ ] 👁️ I have gone through the code and removed any temporary changes (commented lines, prints, debug statements etc.).
- [ ] ⚒️ I have fixed any errors/warnings shown by the analyzer/linter.
- [ ] 📝 I have added documentation, comments and logging wherever required.
- [ ] 🧪 I have added necessary tests for these changes.
- [ ] 🔎 I have ensured all existing tests are passing.

## Reviewers

<!-- Tag the reviewers of this PR -->

## Pre-launch Checklist (For Reviewers)

As a reviewer I ensure that:

- [ ] ✴️ This PR follows the standard PR template.
- [ ] 🪩 The information in this PR properly reflects the code changes.
- [ ] 🧪 All the necessary tests for this PR's are passing.

## Pre-launch Checklist (For QA)

- [ ] 👌 It passes the acceptance criteria.

## Pre-launch Checklist (For Maintainer)

- [ ] [MAINTAINER_NAME] I make sure this PR fulfills its purpose.

## Summary by Sourcery

Prevent ZigZagSeries from reading outside its data range when computing visible entries and align behavior with the base implementation for out-of-range windows.

Bug Fixes:
- Handle negative and out-of-bounds start/end indices in ZigZagSeries visible entry calculation to avoid RangeError when the visible window lies outside the data range.

Enhancements:
- Add unit tests covering ZigZagSeries visibleEntries behavior for windows before, after, and overlapping the data.

Build:
- Update deriv_technical_analysis dependency to version 1.1.3.

Tests:
- Add ZigZagSeries tests to verify empty visible entries for non-overlapping windows and non-empty results for overlapping windows.