### PR TITLE
fix: keep data anchored to the left edge in data-fit mode

### DIFF
--- a/lib/src/deriv_chart/chart/x_axis/x_axis_model.dart
+++ b/lib/src/deriv_chart/chart/x_axis/x_axis_model.dart
@@ -543,7 +543,8 @@ class XAxisModel extends ChangeNotifier {
 
   /// Called to scale the chart
   void scale(double scale) {
-    _msPerPx = (_prevMsPerPx! / scale).clamp(_minMsPerPx, _scaleOutMsPerPxLimit);
+    _msPerPx =
+        (_prevMsPerPx! / scale).clamp(_minMsPerPx, _scaleOutMsPerPxLimit);
     onScale?.call();
     notifyListeners();
   }

--- a/lib/src/deriv_chart/chart/x_axis/x_axis_model.dart
+++ b/lib/src/deriv_chart/chart/x_axis/x_axis_model.dart
@@ -90,6 +90,7 @@ class XAxisModel extends ChangeNotifier {
         _maxCurrentTickOffset;
     _rightBoundEpoch = _shiftEpoch(_maxEpoch, _defaultTickOffset);
     _dataFitMode = startWithDataFitMode;
+    _anchorDataToLeft = startWithDataFitMode;
     _minIntervalWidth = minIntervalWidth ?? 1;
     _maxIntervalWidth = maxIntervalWidth ?? 80;
 
@@ -165,6 +166,15 @@ class XAxisModel extends ChangeNotifier {
   double? _prevScrollAnimationValue;
   bool _autoPanEnabled = true;
   late bool _dataFitMode;
+
+  /// Whether the chart's data stays anchored to the left edge.
+  ///
+  /// Unlike [_dataFitMode], which any scale or pan gesture turns off, this stays
+  /// on for the lifetime of the model. It marks charts that show a bounded data
+  /// window — contract details — where the oldest entry must never drift to the
+  /// right of the position data-fit mode gives it.
+  late bool _anchorDataToLeft;
+
   double _msPerPx = 1000;
   double? _prevMsPerPx;
   late int _granularity;
@@ -191,7 +201,17 @@ class XAxisModel extends ChangeNotifier {
   set rightBoundEpoch(int value) => _rightBoundEpoch = value;
 
   /// Current scrolling lower bound.
-  int get _minRightBoundEpoch => _shiftEpoch(_minEpoch, _maxCurrentTickOffset);
+  ///
+  /// When [_anchorDataToLeft] is set, this is the [rightBoundEpoch] that puts
+  /// the oldest entry exactly where data-fit mode would: [_dataFitPadding.left]
+  /// px from the left edge. Scrolling or zooming may push the oldest entry off
+  /// the left edge, but never further right than that.
+  int get _minRightBoundEpoch {
+    if (_anchorDataToLeft && width != null) {
+      return _shiftEpoch(_minEpoch, width! - _dataFitPadding.left);
+    }
+    return _shiftEpoch(_minEpoch, _maxCurrentTickOffset);
+  }
 
   /// Current scrolling upper bound.
   int get _maxRightBoundEpoch => _shiftEpoch(_maxEpoch, _maxCurrentTickOffset);
@@ -222,6 +242,26 @@ class XAxisModel extends ChangeNotifier {
 
   /// Starting value for [_msPerPx].
   double get _defaultMsPerPx => _granularity / defaultIntervalWidth;
+
+  /// Effective zoom-out limit applied to user-driven scaling.
+  ///
+  /// Charts with [_anchorDataToLeft] never zoom out past the scale at which all
+  /// of the data already fits on screen. Past that point there is nothing left
+  /// to reveal: the data would just shrink into a band at the left edge, and a
+  /// live chart would stop being able to follow the current tick.
+  double get _scaleOutMsPerPxLimit {
+    if (_anchorDataToLeft && width != null && (_entries?.isNotEmpty ?? false)) {
+      final double pxTargetDataWidth = width! - _dataFitPadding.horizontal;
+      if (pxTargetDataWidth > 0) {
+        // Same expression as [_fitData], so the limit lands exactly on the
+        // data-fit scale.
+        final int msDataDuration = _entries!.length * granularity;
+        return (msDataDuration / pxTargetDataWidth)
+            .clamp(_minMsPerPx, _maxMsPerPx);
+      }
+    }
+    return _maxMsPerPx;
+  }
 
   /// Whether data fit mode is enabled.
   /// Doesn't mean it is currently active viewing mode.
@@ -503,7 +543,7 @@ class XAxisModel extends ChangeNotifier {
 
   /// Called to scale the chart
   void scale(double scale) {
-    _msPerPx = (_prevMsPerPx! / scale).clamp(_minMsPerPx, _maxMsPerPx);
+    _msPerPx = (_prevMsPerPx! / scale).clamp(_minMsPerPx, _scaleOutMsPerPxLimit);
     onScale?.call();
     notifyListeners();
   }
@@ -578,6 +618,13 @@ class XAxisModel extends ChangeNotifier {
     if (_minRightBoundEpoch <= _maxRightBoundEpoch) {
       _rightBoundEpoch =
           _rightBoundEpoch.clamp(_minRightBoundEpoch, _maxRightBoundEpoch);
+    } else if (_anchorDataToLeft) {
+      // The data no longer spans the viewport, so "oldest entry no further
+      // right than its data-fit position" and "newest entry within
+      // [_maxCurrentTickOffset] of the right edge" can't both hold. The left
+      // anchor wins — deferring to the upper bound here is what would otherwise
+      // push the oldest entry towards the right edge as the user zooms out.
+      _rightBoundEpoch = _minRightBoundEpoch;
     }
   }
 


### PR DESCRIPTION
## What

For charts started in data-fit mode, the oldest entry now stays anchored to the left edge, and zooming out stops at the data-fit scale.

Three changes in `XAxisModel`:

1. **New `_anchorDataToLeft` flag**, set from `startWithDataFitMode`. Unlike `_dataFitMode` — which any pan or scale gesture turns off — this stays on for the lifetime of the model.
2. **`_minRightBoundEpoch`** now returns the `rightBoundEpoch` that puts the oldest entry exactly where data-fit mode would (`_dataFitPadding.left` px from the left edge), instead of a bound derived from `maxCurrentTickOffset`.
3. **`scale()`** clamps against `_scaleOutMsPerPxLimit` — the data-fit scale — rather than `_maxMsPerPx`.

When the data no longer spans the viewport, the left anchor wins over the `maxCurrentTickOffset` upper bound.

## Why

These charts show a bounded data window (e.g. contract details), not a live stream, so the old behaviour was wrong in two ways:

- Panning or zooming let the oldest entry drift right of its data-fit position, leaving a growing gap on the left.
- Zooming out past the data-fit scale revealed nothing — the data just shrank into a band at the left edge, and a live chart lost the ability to follow the current tick.

## Scope

Only affects charts constructed with `startWithDataFitMode: true`. Charts that start in follow-current-tick mode keep the existing bounds and zoom limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure charts initialized in data-fit mode keep their data anchored to the left edge and prevent zooming out beyond the data-fit scale.

Bug Fixes:
- Prevent oldest data points in data-fit charts from drifting right and leaving a gap on the left when panning or zooming.
- Stop users from zooming out past the data-fit scale when all data already fits in the viewport, avoiding useless extra zoom.

Enhancements:
- Introduce a persistent left-anchor mode for bounded data-window charts that overrides tick-offset bounds when data no longer spans the viewport.